### PR TITLE
Explicitly set content-length in header

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = function (options) {
   return function (req, res, next) {
     req.removeAllListeners('data')
     req.removeAllListeners('end')
+    if(req.headers['content-length'] !== undefined){
+      req.headers['content-length'] = options.stringify(req[options.property]).length
+    }
     next()
     process.nextTick(function () {
       if(req[options.property]) {


### PR DESCRIPTION
Incorrect value for content-length can cause request to hang waiting on remainder of body. Issue explained here w/ example http://stackoverflow.com/questions/26877928/http-request-does-not-emit-end-after-proxy/26894538#26894538