### PR TITLE
Set content-length in bytes instead of characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (options) {
     req.removeAllListeners('data')
     req.removeAllListeners('end')
     if(req.headers['content-length'] !== undefined){
-      req.headers['content-length'] = options.stringify(req[options.property]).length
+      req.headers['content-length'] = Buffer.byteLength(options.stringify(req[options.property]), 'utf8')
     }
     next()
     process.nextTick(function () {


### PR DESCRIPTION
If the body contained multi-byte UTF-8 characters, the content-length would be smaller than the actual length in bytes and the receiving end would probably fail with a "unexpected end of input" error.

This fixes it by calculating the actual byte length of the body. UTF-8 is assumed to be used, since it is the default in node.js. For single-byte encodings this does not change anything anyway.
